### PR TITLE
Add Firebase emulator setup docs

### DIFF
--- a/FIREBASE_EMULATORS.md
+++ b/FIREBASE_EMULATORS.md
@@ -1,0 +1,64 @@
+# Firebase Emulator Suite
+
+Este guia explica como executar todo o backend do projeto localmente usando o **Firebase Emulator Suite**. Isso inclui Auth, Firestore, Storage e Functions.
+
+## Pré-requisitos
+
+- Node.js 18+
+- [Firebase CLI](https://firebase.google.com/docs/cli) instalado globalmente:
+  ```bash
+  npm install -g firebase-tools
+  ```
+
+## Configuração
+
+1. Na raiz do repositório, edite o arquivo `firebase.json` e adicione a seção `emulators` caso ela não exista:
+
+   ```json
+   {
+     "firestore": { "rules": "firestore.rules", "indexes": "firestore.indexes.json" },
+     "storage": { "rules": "storage.rules" },
+     "functions": { "source": "functions" },
+     "hosting": { "public": "dist" },
+     "emulators": {
+       "auth": { "port": 9099 },
+       "firestore": { "port": 8080 },
+       "storage": { "port": 9199 },
+       "functions": { "port": 5001 },
+       "ui": { "enabled": true, "port": 4000 }
+     }
+   }
+   ```
+
+2. Instale as dependências das Functions (caso ainda não tenha feito):
+
+   ```bash
+   cd functions
+   npm install
+   cd ..
+   ```
+
+## Executando
+
+Para iniciar todos os emuladores, execute na raiz do projeto:
+
+```bash
+firebase emulators:start
+```
+
+A interface do Emulator Suite ficará disponível em `http://localhost:4000`.
+
+Você pode opcionalmente especificar quais serviços deseja iniciar:
+
+```bash
+firebase emulators:start --only auth,firestore,storage,functions
+```
+
+Para preservar os dados entre execuções, utilize as flags `--import` e `--export-on-exit`:
+
+```bash
+firebase emulators:start --import=./local-data --export-on-exit
+```
+
+Com os emuladores rodando, o frontend e as Functions se comunicarão com as instâncias locais, permitindo testes completos do backend sem depender do Firebase em produção.
+

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Siga o guia detalhado em [FIREBASE_SETUP.md](./FIREBASE_SETUP.md) para:
 - **[API.md](./API.md)** - Documentação de APIs e integrações
 - **[DEPLOYMENT.md](./DEPLOYMENT.md)** - Guia de deploy
 - **[FIREBASE_SETUP.md](./FIREBASE_SETUP.md)** - Configuração Firebase
+- **[FIREBASE_EMULATORS.md](./FIREBASE_EMULATORS.md)** - Executar Firebase Emulator Suite
 
 ## 🎯 Como Usar
 


### PR DESCRIPTION
## Summary
- create `FIREBASE_EMULATORS.md` with instructions on running the local Firebase Emulator Suite
- link the new doc from `README.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because the container lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68518d480a94832ba5839b80066e03c3