### PR TITLE
Add OCR endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -352,9 +352,15 @@ const generateDocument = async (request: GenerationRequest): Promise<GenerationR
 
 ### OCR Service
 ```typescript
-// POST /api/ocr
+// POST /ocr
 const processOCR = async (file: File): Promise<{ text: string; confidence: number }> => {
-  // Implementação alternativa ao Tesseract local
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch('/ocr', {
+    method: 'POST',
+    body: formData
+  });
+  return res.json();
 };
 ```
 

--- a/README-BACKEND.md
+++ b/README-BACKEND.md
@@ -143,6 +143,21 @@ Gera documento usando IA.
 }
 ```
 
+### POST `/ocr`
+Realiza OCR no arquivo de imagem enviado e retorna o texto extraído.
+
+**Parâmetros:**
+- `file`: Imagem JPG, PNG, GIF, BMP ou TIFF (multipart)
+
+**Response:**
+```json
+{
+  "success": true,
+  "text": "Conteúdo OCR",
+  "confidence": 92.3
+}
+```
+
 ## 🔒 Segurança
 
 ### Autenticação

--- a/functions/package.json
+++ b/functions/package.json
@@ -26,7 +26,8 @@
     "docx": "^8.5.0",
     "jszip": "^3.10.1",
     "uuid": "^9.0.1",
-    "joi": "^17.11.0"
+    "joi": "^17.11.0",
+    "tesseract.js": "^6.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.15",

--- a/functions/src/functions/ocr.ts
+++ b/functions/src/functions/ocr.ts
@@ -1,0 +1,51 @@
+import { onRequest } from 'firebase-functions/v2/https';
+import * as express from 'express';
+import * as multer from 'multer';
+import * as cors from 'cors';
+import { OCRService } from '../services/ocrService';
+import { validateFile } from '../utils/validation';
+import { handleError, ValidationError } from '../utils/errors';
+
+const app = express();
+app.use(cors({ origin: true }));
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 20 * 1024 * 1024, files: 1 }
+});
+
+app.post('/ocr', upload.single('file'), async (req, res) => {
+  try {
+    const file = req.file;
+    if (!file) {
+      throw new ValidationError('Arquivo de imagem é obrigatório');
+    }
+
+    validateFile(file, [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/bmp',
+      'image/tiff'
+    ], 20 * 1024 * 1024);
+
+    const ocrService = new OCRService();
+    const { text, confidence } = await ocrService.processImage(file.buffer);
+
+    res.json({ success: true, text, confidence });
+  } catch (error) {
+    const errorResponse = handleError(error);
+    res.status(errorResponse.statusCode).json(errorResponse);
+  }
+});
+
+app.get('/health', (_req, res) => {
+  res.json({
+    status: 'OK',
+    service: 'ocr',
+    timestamp: new Date().toISOString(),
+    version: '1.0.0'
+  });
+});
+
+export const ocr = onRequest({ timeoutSeconds: 60, memory: '512MiB' }, app);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,6 +11,7 @@ export { criarAgenteComPrompt } from './functions/criarAgenteComPrompt';
 export { listarAgentesWorkspace } from './functions/listarAgentesWorkspace';
 export { listarPromptsPublicos } from './functions/listarPromptsPublicos';
 export { exportarDocumento } from './functions/exportarDocumento';
+export { ocr } from './functions/ocr';
 
 // Função de teste para verificar se o backend está funcionando
 export { onRequest } from 'firebase-functions/v2/https';

--- a/functions/src/services/ocrService.ts
+++ b/functions/src/services/ocrService.ts
@@ -1,0 +1,22 @@
+import { createWorker } from 'tesseract.js';
+import * as logger from 'firebase-functions/v2/logger';
+
+export interface OcrResult {
+  text: string;
+  confidence: number;
+}
+
+export class OCRService {
+  async processImage(buffer: Buffer): Promise<OcrResult> {
+    const worker = await createWorker('por');
+    const { data } = await worker.recognize(buffer);
+    await worker.terminate();
+
+    logger.info('OCR processing finished', { confidence: data.confidence });
+
+    return {
+      text: data.text.trim(),
+      confidence: data.confidence
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- implement `OCRService` for server-side text extraction
- expose OCR API endpoint in Firebase functions
- export OCR function from the entry point
- document the new endpoint in backend docs and API guide
- include tesseract.js dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix functions run build` *(fails: Cannot find module 'firebase-admin' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68518d40651c832b92dac166a6223dc5